### PR TITLE
Handlers can accept an optional session argument

### DIFF
--- a/lib/messaging/controls/handler.rb
+++ b/lib/messaging/controls/handler.rb
@@ -42,6 +42,18 @@ module Messaging
           end
         end
       end
+
+      module SessionArgument
+        class Example
+          include Messaging::Handle
+
+          attr_accessor :session
+
+          def configure(session: nil)
+            self.session = session
+          end
+        end
+      end
     end
   end
 end

--- a/lib/messaging/controls/handler.rb
+++ b/lib/messaging/controls/handler.rb
@@ -54,7 +54,7 @@ module Messaging
           end
         end
 
-        module Invalid
+        module Anomaly
           module Required
             class Example
               include Messaging::Handle

--- a/lib/messaging/controls/handler.rb
+++ b/lib/messaging/controls/handler.rb
@@ -53,6 +53,35 @@ module Messaging
             self.session = session
           end
         end
+
+        module Invalid
+          module Required
+            class Example
+              include Messaging::Handle
+
+              def configure(session:)
+              end
+            end
+          end
+
+          module Positional
+            class Example
+              include Messaging::Handle
+
+              def configure(session)
+              end
+            end
+
+            module Optional
+              class Example
+                include Messaging::Handle
+
+                def configure(session=nil)
+                end
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/lib/messaging/handle.rb
+++ b/lib/messaging/handle.rb
@@ -19,18 +19,34 @@ module Messaging
     end
 
     module Build
-      def build(strict: nil)
+      def build(strict: nil, session: nil)
         instance = new
         instance.strict = strict
         Log.configure(instance, attr_name: :handler_logger)
-        instance.configure
+
+        if Build.configure_session?(instance)
+          instance.configure(session: session)
+        else
+          instance.configure
+        end
+
         instance
+      end
+
+      def self.configure_session?(instance)
+        configure_method = instance.method(:configure)
+
+        if configure_method.parameters.any?
+          true
+        else
+          false
+        end
       end
     end
 
     module Call
-      def call(message_or_message_data, strict: nil)
-        instance = build(strict: strict)
+      def call(message_or_message_data, strict: nil, session: session)
+        instance = build(strict: strict, session: session)
         instance.(message_or_message_data)
       end
     end

--- a/lib/messaging/handle.rb
+++ b/lib/messaging/handle.rb
@@ -55,7 +55,7 @@ module Messaging
     end
 
     module Call
-      def call(message_or_message_data, strict: nil, session: session)
+      def call(message_or_message_data, strict: nil, session: nil)
         instance = build(strict: strict, session: session)
         instance.(message_or_message_data)
       end

--- a/lib/messaging/handle.rb
+++ b/lib/messaging/handle.rb
@@ -36,11 +36,21 @@ module Messaging
       def self.configure_session?(instance)
         configure_method = instance.method(:configure)
 
-        if configure_method.parameters.any?
-          true
-        else
-          false
+        parameter_type, _ = configure_method.parameters.find do |type, name|
+          name == :session
         end
+
+        return false if parameter_type.nil?
+
+        return true if parameter_type == :key
+
+        error_message = "Optional session parameter of configure is not a keyword argument (Type: #{parameter_type.inspect})"
+        logger.error { error_message }
+        raise ArgumentError, error_message
+      end
+
+      def self.logger
+        @logger ||= Log.build(self)
       end
     end
 

--- a/test/automated/handle/session_configuration/bare_configure_method.rb
+++ b/test/automated/handle/session_configuration/bare_configure_method.rb
@@ -1,0 +1,27 @@
+require_relative '../../automated_init'
+
+context "Handle" do
+  context "Session Configuration" do
+    context "Bare Configure Method" do
+      handler_class = Controls::Handler::Example
+
+      context "Given" do
+        session = Object.new
+
+        test "Argument error not raised" do
+          refute proc { handler_class.build(session: session) } do
+            raises_error?(ArgumentError)
+          end
+        end
+      end
+
+      context "Not Given" do
+        test "Argument error not raised" do
+          refute proc { handler_class.build } do
+            raises_error?(ArgumentError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/automated/handle/session_configuration/configure_method_accepts_session.rb
+++ b/test/automated/handle/session_configuration/configure_method_accepts_session.rb
@@ -1,0 +1,27 @@
+require_relative '../../automated_init'
+
+context "Handle" do
+  context "Session Configuration" do
+    context "Configure Method Accepts Session Argument" do
+      handler_class = Controls::Handler::SessionArgument::Example
+
+      context "Given" do
+        session = Object.new
+
+        handler = handler_class.build(session: session)
+
+        test "Session is passed to configure method" do
+          assert(handler.session.eql?(session))
+        end
+      end
+
+      context "Not Given" do
+        test "Argument error not raised" do
+          refute proc { handler_class.build } do
+            raises_error?(ArgumentError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/automated/handle/session_configuration/configure_method_accepts_session.rb
+++ b/test/automated/handle/session_configuration/configure_method_accepts_session.rb
@@ -11,7 +11,7 @@ context "Handle" do
         handler = handler_class.build(session: session)
 
         test "Session is passed to configure method" do
-          assert(handler.session.eql?(session))
+          assert(handler.session.equal?(session))
         end
       end
 

--- a/test/automated/handle/session_configuration/invalid_session_parameter.rb
+++ b/test/automated/handle/session_configuration/invalid_session_parameter.rb
@@ -1,0 +1,73 @@
+require_relative '../../automated_init'
+
+context "Handle" do
+  context "Session Configuration" do
+    context "Configure Method Includes Invalid Session Parameter" do
+      context "Session is positional argument" do
+        handler_class = Controls::Handler::SessionArgument::Invalid::Positional::Example
+
+        context "Given" do
+          session = Object.new
+
+          test "Argument error is raised" do
+            assert proc { handler_class.build(session: session) } do
+              raises_error?(ArgumentError)
+            end
+          end
+        end
+
+        context "Not Given" do
+          test "Argument error is raised" do
+            assert proc { handler_class.build } do
+              raises_error?(ArgumentError)
+            end
+          end
+        end
+      end
+
+      context "Session is optional positional argument" do
+        handler_class = Controls::Handler::SessionArgument::Invalid::Positional::Optional::Example
+
+        context "Given" do
+          session = Object.new
+
+          test "Argument error is raised" do
+            assert proc { handler_class.build(session: session) } do
+              raises_error?(ArgumentError)
+            end
+          end
+        end
+
+        context "Not Given" do
+          test "Argument error is raised" do
+            assert proc { handler_class.build } do
+              raises_error?(ArgumentError)
+            end
+          end
+        end
+      end
+
+      context "Session is required keyword argument" do
+        handler_class = Controls::Handler::SessionArgument::Invalid::Required::Example
+
+        context "Given" do
+          session = Object.new
+
+          test "Argument error is raised" do
+            assert proc { handler_class.build(session: session) } do
+              raises_error?(ArgumentError)
+            end
+          end
+        end
+
+        context "Not Given" do
+          test "Argument error is raised" do
+            assert proc { handler_class.build } do
+              raises_error?(ArgumentError)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/automated/handle/session_configuration/invalid_session_parameter.rb
+++ b/test/automated/handle/session_configuration/invalid_session_parameter.rb
@@ -2,9 +2,9 @@ require_relative '../../automated_init'
 
 context "Handle" do
   context "Session Configuration" do
-    context "Configure Method Includes Invalid Session Parameter" do
+    context "Configure Method Includes Incorrect Session Parameter" do
       context "Session is positional argument" do
-        handler_class = Controls::Handler::SessionArgument::Invalid::Positional::Example
+        handler_class = Controls::Handler::SessionArgument::Anomaly::Positional::Example
 
         context "Given" do
           session = Object.new
@@ -26,7 +26,7 @@ context "Handle" do
       end
 
       context "Session is optional positional argument" do
-        handler_class = Controls::Handler::SessionArgument::Invalid::Positional::Optional::Example
+        handler_class = Controls::Handler::SessionArgument::Anomaly::Positional::Optional::Example
 
         context "Given" do
           session = Object.new
@@ -48,7 +48,7 @@ context "Handle" do
       end
 
       context "Session is required keyword argument" do
-        handler_class = Controls::Handler::SessionArgument::Invalid::Required::Example
+        handler_class = Controls::Handler::SessionArgument::Anomaly::Required::Example
 
         context "Given" do
           session = Object.new


### PR DESCRIPTION
This work is part of a greater initiative towards allowing sessions passed into the consumer to be distributed pervasively down the whole stack through the messaging handlers.

With this PR, handler classes may (or may not) define configure methods that accept an optional session parameter. When the handler is constructed via `.build`, a session value can be given that will be passed to the configure method. For example:

```ruby
class SomeHandler
  dependency :write, Messaging::Postgres::Write

  def configure(session: nil)
    Write.configure(self, session: session)
  end
end

# some_session will get passed to configure
SomeHandler.build(session: some_session)
```

If the configure method does _not_ accept a session argument, `.build` will _not_ try to supply a session. For example:

```ruby
class TraditionalHandler
  def configure # Note: no session argument
  end
end

# This works
TraditionalHandler.build(session: some_session)
```

Therefore, this should _not_ be considered a breaking change.