### PR TITLE
correlation_stream_name of nil is never correlated

### DIFF
--- a/lib/messaging/message/metadata.rb
+++ b/lib/messaging/message/metadata.rb
@@ -70,6 +70,8 @@ module Messaging
       def correlated?(stream_name)
         correlation_stream_name = self.correlation_stream_name
 
+        return false if correlation_stream_name.nil?
+
         stream_name = Category.normalize(stream_name)
 
         if MessageStore::StreamName.category?(stream_name)

--- a/test/automated/message/metadata/correlated/category_input/no_correlation_stream.rb
+++ b/test/automated/message/metadata/correlated/category_input/no_correlation_stream.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../automated_init'
+
+context "Message" do
+  context "Metadata" do
+    context "Correlated" do
+      context "Category Input" do
+        context "No Correlation Stream Name" do
+          metadata = Controls::Metadata.example
+
+          metadata.correlation_stream_name = nil
+
+          test "Is not correlated" do
+            refute(metadata.correlated?('someStream'))
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/automated/message/metadata/correlated/entity_stream_input/no_correlation_stream.rb
+++ b/test/automated/message/metadata/correlated/entity_stream_input/no_correlation_stream.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../automated_init'
+
+context "Message" do
+  context "Metadata" do
+    context "Correlated" do
+      context "Entity Stream Input" do
+        context "No Correlation Stream Name" do
+          metadata = Controls::Metadata.example
+
+          metadata.correlation_stream_name = nil
+
+          test "Is not correlated" do
+            refute(metadata.correlated?("someStream-123"))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously it crashes if compared against an entity stream

```
/Users/matt/notion/components/artwork_component/gems/ruby/2.5.0/gems/evt-message_store-0.7.1.0/lib/message_store/stream_name.rb:29:in `get_category': undefined method `split' for nil:NilClass (NoMethodError)
              from /Users/matt/notion/components/artwork_component/gems/ruby/2.5.0/gems/evt-messaging-0.29.0.6/lib/messaging/message/metadata.rb:76:in `correlated?'
```