### PR TITLE
Handle macro returns method name

### DIFF
--- a/lib/messaging/handle.rb
+++ b/lib/messaging/handle.rb
@@ -110,7 +110,7 @@ module Messaging
           name = message_or_message_data.message_name
         end
 
-        "handle_#{name}"
+        "handle_#{name}".to_sym
       end
     end
 
@@ -122,8 +122,11 @@ module Messaging
       end
 
       def handle_macro(message_class, &blk)
-        define_handler_method(message_class, &blk)
+        handler_method_name = define_handler_method(message_class, &blk)
+
         message_registry.register(message_class)
+
+        handler_method_name
       end
       alias :handle :handle_macro
 

--- a/lib/messaging/handle.rb
+++ b/lib/messaging/handle.rb
@@ -86,20 +86,20 @@ module Messaging
       extend self
 
       def handler(message_or_message_data)
-        name = handler_name(message_or_message_data)
+        handler_method_name = handler_method_name(message_or_message_data)
 
-        if method_defined?(name)
-          return name
+        if method_defined?(handler_method_name)
+          return handler_method_name
         else
           return nil
         end
       end
 
       def handles?(message_or_message_data)
-        method_defined? handler_name(message_or_message_data)
+        method_defined? handler_method_name(message_or_message_data)
       end
 
-      def handler_name(message_or_message_data)
+      def handler_method_name(message_or_message_data)
         name = nil
 
         if message_or_message_data.is_a? MessageStore::MessageData::Read
@@ -131,7 +131,7 @@ module Messaging
       alias :handle :handle_macro
 
       def define_handler_method(message_class, &blk)
-        handler_method_name = handler_name(message_class)
+        handler_method_name = handler_method_name(message_class)
 
         if blk.nil?
           error_msg = "Handler for #{message_class.name} is not correctly defined. It must have a block."

--- a/test/automated/handle/macro/return_value.rb
+++ b/test/automated/handle/macro/return_value.rb
@@ -1,0 +1,23 @@
+require_relative '../../automated_init'
+
+context "Handle" do
+  context "Macro" do
+    context "Return Value" do
+      return_value = nil
+      method_name = :handle_some_message
+
+      Class.new do
+        include Messaging::Handle
+
+        return_value = handle Controls::Message::SomeMessage do |message|
+        end
+      end
+
+      comment return_value.inspect
+
+      test "Is method name" do
+        assert(return_value == method_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`def` and `define_method` return the method name, it's useful for this to as well when used in building higher level abstractions.

I wasn't sure about testing this because the test for it hides the usage in a control. I'm up for suggestions on it.