### PR TITLE
Handler logging logs on handle blocks

### DIFF
--- a/lib/messaging/handle.rb
+++ b/lib/messaging/handle.rb
@@ -209,7 +209,12 @@ module Messaging
 
         message_type = message.message_type
 
+        handler_logger.trace(tag: [:handle, :message_data]) { "Handling Message Data (Type: #{message_type}, Method: #{handler})" }
+
         public_send(handler, message)
+
+        handler_logger.info(tags: [:handle, :message_data]) { "Handled message data (Type: #{message_data.type})" }
+        handler_logger.info(tags: [:data, :message_data]) { message_data.pretty_inspect }
       else
         if respond_to?(:handle)
           message_type = message_data.type


### PR DESCRIPTION
https://github.com/eventide-project/messaging/commit/b3c03528df1ff6788e2ef2411edb7cb068061538 accidentally removed handler logging for handlers defined using the block syntax.

Re-adds the logging lines around the handle blocks.