### PR TITLE
Strict value is not null coalesced from a false value

### DIFF
--- a/lib/messaging/handle.rb
+++ b/lib/messaging/handle.rb
@@ -159,9 +159,9 @@ module Messaging
       end
     end
 
-## Can't null-coalesce here. It's a boolean. Use expanded form of `if` block - Scott, Mon Oct 16 2023
     def strict
-      @strict ||= Defaults.strict
+      @strict = Defaults.strict if @strict.nil?
+      @strict
     end
     alias :strict? :strict
 
@@ -174,7 +174,7 @@ module Messaging
     end
 
     def handle_message(message, strict: nil)
-      strict ||= self.strict?
+      strict = self.strict? if strict.nil?
 
       handler_logger.trace(tags: [:dispatch, :message]) { "Dispatching message (Message class: #{message.class.name})" }
       handler_logger.trace(tags: [:data, :message]) { message.pretty_inspect }
@@ -202,7 +202,7 @@ module Messaging
     end
 
     def handle_message_data(message_data, strict: nil)
-      strict ||= self.strict?
+      strict = self.strict? if strict.nil?
 
       handler_logger.trace(tags: [:dispatch, :message_data]) { "Dispatching message data (Type: #{message_data.type})" }
       handler_logger.trace(tags: [:data, :message_data]) { message_data.pretty_inspect }


### PR DESCRIPTION
Resolves #28 (Strict value can't be null coalesced from a false value)

# Background

Ruby's conditional assignment operator (`||=`) is typically used for assigning default values to variables:

```
def some_method(some_variable=nil)
  some_variable ||= "some-default-value"
  # ...
end
```

However, it has an issue with boolean values:

```
def some_method(some_boolean_variable=nil)
  some_boolean_variable ||= true
  # ...
end
```

If `false` is passed to some_method, the conditional assignment operator will treat `false` exactly the same as `nil`. As a result, boolean variables must be given default values differently from other types of values:

```
def some_method(some_boolean_variable=nil)
  some_boolean_variable = true if some_boolean_variable.nil?
  # ...
end
```

# Proposed Standard: Boolean Attributes With Default Value

Messaging Handle has an boolean attribute `strict`, which has a default value:

```
def strict
  @strict ||= Defaults.strict
end
attr_writer :strict
```

This is a mistake, since the conditional assignment operator can't be used with boolean value. Instead, we propose the following:

```
def strict
  @strict = Defaults.strict if @strict.nil?
  @strict
end
attr_writer :strict
```

This proposed standard follows the existing norm for how default boolean values are assigned to local variables in methods.